### PR TITLE
feat: add npmignore file for publish

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,4 @@ test/
 nest-cli.json
 tsconfig.build.json
 tsconfig.json
+dist/tsconfig.build.tsbuildinfo

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,8 @@
+dockers/
+src/
+test/
+.eslintrc.js
+.prettierrc
+nest-cli.json
+tsconfig.build.json
+tsconfig.json

--- a/.npmignore
+++ b/.npmignore
@@ -1,9 +1,0 @@
-dockers/
-src/
-test/
-.eslintrc.js
-.prettierrc
-nest-cli.json
-tsconfig.build.json
-tsconfig.json
-dist/tsconfig.build.tsbuildinfo

--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
     "nestjs",
     "transporter"
   ],
+  "files": [
+    "dist",
+    "!dist/tsconfig.build.tsbuildinfo"
+  ],
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "nest build",


### PR DESCRIPTION
The general idea is to just publish the `dist` folder to npm for this library and in order to do this, an `.npmignore` file is needed, otherwise `npm publish` will just take the files specified in `.gitignore`.

**Question:**
Do we also need to exclude the `dist/tsconfig.build.tsbuildinfo` file?
